### PR TITLE
#23 | Button text color

### DIFF
--- a/ui/components/ExpertCard.tsx
+++ b/ui/components/ExpertCard.tsx
@@ -83,7 +83,7 @@ const ExpertCard = ({ expert, me }: any) => {
               return (
                 <Button
                   color="success"
-                  className="mr-2 my-2 text-black"
+                  className="mr-2 my-2 text-black font-weight-bold"
                   size="sm"
                   onClick={() => window.open(url)}
                   key={`availability-btn-${slot}-${expert.id}`}

--- a/ui/components/ExpertCard.tsx
+++ b/ui/components/ExpertCard.tsx
@@ -50,7 +50,7 @@ const ExpertCard = ({ expert, me }: any) => {
               <Badge
                 color="success"
                 pill
-                className="mr-2"
+                className="mr-2 text-black"
                 key={`availability-${exp.key}-${expert.id}`}
               >{`${exp.day} ${exp.startTime}-${exp.endTime}`}</Badge>
             ))}
@@ -83,7 +83,7 @@ const ExpertCard = ({ expert, me }: any) => {
               return (
                 <Button
                   color="success"
-                  className="mr-2 my-2"
+                  className="mr-2 my-2 text-black"
                   size="sm"
                   onClick={() => window.open(url)}
                   key={`availability-btn-${slot}-${expert.id}`}


### PR DESCRIPTION
## In expert card, update availabilities tags and schedule buttons texts to be black
<img width="337" alt="image" src="https://user-images.githubusercontent.com/48219965/211214453-bdad2b82-9fe6-480c-ba16-7822284efdd8.png">
 